### PR TITLE
feat: enable mise manager and mise.lock maintenance

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,6 +6,7 @@
     "helpers:pinGitHubActionDigests",
     "github>joryirving/renovate-config:autoMerge.json5",
     "github>joryirving/renovate-config:labels.json5",
+    "github>joryirving/renovate-config:mise.json5",
     "github>joryirving/renovate-config:packageRules.json5",
     "github>joryirving/renovate-config:semanticCommits.json5",
     "mergeConfidence:all-badges",

--- a/mise.json5
+++ b/mise.json5
@@ -1,0 +1,16 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  mise: {
+    enabled: true,
+    managerFilePatterns: ["/(^|/)\\.mise/config\\.toml$/"],
+  },
+  packageRules: [
+    {
+      description: "Keep mise.lock up to date",
+      matchManagers: ["mise"],
+      lockFileMaintenance: {
+        enabled: true,
+      },
+    },
+  ],
+}


### PR DESCRIPTION
## Problem

The shared config had rules in `semanticCommits.json5`, `labels.json5`, and `autoMerge.json5` keyed on the `mise` manager, but the manager itself was never enabled. That meant tool version bumps in `.mise/config.toml` were not picked up by Renovate, leaving `.mise/mise.lock` stale.

Real-world impact: `joryirving/containers` had `gh` and `oxfmt` bumped in `.mise/config.toml` without the corresponding `mise.lock` updates. The Plan CI job fails with `mise install --locked` because the new tool versions are not pinned in the lockfile.

## Changes

- **`mise.json5`** (new): enables the `mise` manager with `managerFilePatterns` for `.mise/config.toml`, and adds a `packageRule` enabling `lockFileMaintenance` for the `mise` manager.
- **`default.json`**: adds the new preset to `extends`.

Validates clean against the Renovate schema.