### PR TITLE
chore: sync base to home-operations/renovate-config upstream

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended",
     "docker:enableMajor",
-    "helpers:pinGitHubActionDigests",
+    "helpers:pinGitHubActionDigestsToSemver",
     "github>joryirving/renovate-config:autoMerge.json5",
     "github>joryirving/renovate-config:labels.json5",
     "github>joryirving/renovate-config:mise.json5",

--- a/default.json
+++ b/default.json
@@ -16,6 +16,10 @@
     ":timezone(America/Edmonton)"
   ],
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 3am on the first day of the month"]
+  },
   "suppressNotifications": [
     "prEditedNotification",
     "prIgnoreNotification"


### PR DESCRIPTION
## Summary
- `helpers:pinGitHubActionDigests` → `helpers:pinGitHubActionDigestsToSemver` — pins action digests but keeps a readable semver comment.
- Enable monthly `lockFileMaintenance` (scheduled `before 3am on the first day of the month`).

Both match `home-operations/renovate-config`, which this config forked from and had drifted behind. Inherited by every consumer (home-ops, containers).

## Impact
- `lockFileMaintenance` is a no-op in home-ops (no lockfiles); in containers it refreshes `go.sum` monthly. Scheduled so it stays quiet.

## Verification
- `default.json` parses as valid JSON.