### PR TITLE
feat(mise): run mise install before lock in postUpgradeTasks

### DIFF
--- a/mise.json5
+++ b/mise.json5
@@ -11,6 +11,17 @@
       lockFileMaintenance: {
         enabled: true,
       },
+      // npm-backed mise tools (e.g. oxfmt) can only be locked once their node is
+      // installed. The renovate operator image has no usable node for mise, so it
+      // silently drops them from mise.lock and `mise install --locked` then fails on
+      // every PR. Run `mise install` (installs the config-pinned node) before
+      // `mise lock` so the regenerated lock is complete. Requires `mise install &&
+      // mise lock` in allowedCommands (RENOVATE_ALLOWED_COMMANDS) on the operator.
+      postUpgradeTasks: {
+        commands: ["mise install && mise lock"],
+        fileFilters: ["**/mise.lock"],
+        executionMode: "branch",
+      },
     },
   ],
 }


### PR DESCRIPTION
Adds a `postUpgradeTasks` step that runs `mise install && mise lock` (instead of letting the operator run a bare lock) whenever a mise tool updates.

**Why:** the renovate operator regenerates `mise.lock` in a container with no usable node for mise, so npm-backed tools (`oxfmt`) get silently dropped and `mise install --locked` fails on every downstream PR. Running `mise install` first installs the config-pinned node so the npm backend resolves and the lock is complete. Verified the resulting lock passes `mise install --locked` on mise `2026.6.12`.

Keeps `lockFileMaintenance` enabled — it works correctly now that the lock is regenerated with node.

**Requires** the command to be allow-listed on the operator (`RENOVATE_ALLOWED_COMMANDS`) — see the companion home-ops PR. Applies to every repo extending this preset.